### PR TITLE
Weight search results toward recent posts and surface the RSS feed

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -125,6 +125,17 @@ export default function AboutPage() {
             </h2>
             <ul>
               <li>
+                Search results now favour recent posts. Among matches of
+                comparable relevance the newest one ranks first, which suits
+                change alerts, while a decisively better match still wins
+                however old it is.
+              </li>
+              <li>
+                Added an RSS link to the site header so the existing feed of
+                the latest 500 Message Center and Roadmap posts is easier to
+                find.
+              </li>
+              <li>
                 Replaced the ID and title filters with full-text search across
                 every post, including the full body text of expired posts.
                 Search runs entirely in the browser against a pre-built

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -1,6 +1,7 @@
 import {
   LucideProps,
   Moon,
+  Rss,
   SunMedium,
   Twitter,
   type Icon as LucideIcon,
@@ -12,6 +13,7 @@ export const Icons = {
   sun: SunMedium,
   moon: Moon,
   twitter: Twitter,
+  rss: Rss,
   logo: (props: LucideProps) => (
     <svg {...props} xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-squirrel"><path d="M15.236 22a3 3 0 0 0-2.2-5"/><path d="M16 20a3 3 0 0 1 3-3h1a2 2 0 0 0 2-2v-2a4 4 0 0 0-4-4V4"/><path d="M18 13h.01"/><path d="M18 6a4 4 0 0 0-4 4 7 7 0 0 0-7 7c0-5 4-5 4-10.5a4.5 4.5 0 1 0-9 0 2.5 2.5 0 0 0 5 0C7 10 3 11 3 17c0 2.8 2.2 5 5 5h10"/></svg>
   ),

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -27,6 +27,23 @@ export function SiteHeader() {
               ))}
             </div>
             <div className="flex items-center space-x-1">
+              {/* A plain anchor, not next/link: rss.xml is a static file in
+                  public/, not a route the client router can navigate to. */}
+              <a
+                href={siteConfig.links.rss}
+                type="application/rss+xml"
+                title="Subscribe to the RSS feed"
+              >
+                <div
+                  className={buttonVariants({
+                    size: "icon",
+                    variant: "ghost",
+                  })}
+                >
+                  <Icons.rss className="h-5 w-5" />
+                  <span className="sr-only">RSS feed</span>
+                </div>
+              </a>
               <Link
                 href={siteConfig.links.github}
                 target="_blank"

--- a/config/site.ts
+++ b/config/site.ts
@@ -38,6 +38,7 @@ export const siteConfig = {
     },
   ],
   links: {
+    rss: "/rss.xml",
     twitter: "https://twitter.com/merill",
     github: "https://github.com/merill/mc",
   },

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -36,7 +36,13 @@ interface PagefindData {
 
 export interface PagefindResult {
   id: string
+  score: number
   data: () => Promise<PagefindData>
+}
+
+interface PagefindSearchOptions {
+  filters?: Record<string, string[]>
+  sort?: Record<string, "asc" | "desc">
 }
 
 interface PagefindModule {
@@ -44,9 +50,21 @@ interface PagefindModule {
   options: (options: Record<string, unknown>) => Promise<void>
   search: (
     query: string,
-    options?: { filters?: Record<string, string[]> }
+    options?: PagefindSearchOptions
   ) => Promise<{ results: PagefindResult[] }>
 }
+
+// How much a post's recency can lift its relevance score. The newest match in
+// a result set is scored `1 + RECENCY_WEIGHT` times its relevance, the oldest
+// gets no lift, and everything in between scales linearly by its position in
+// the date order.
+//
+// Message Center relevance scores sit in tight clusters — adjacent hits are
+// routinely within a percent of each other — so a 20% spread reliably sorts a
+// tied cluster newest-first, which is what matters for change alerts. It is
+// still small enough that a decisively better match (Pagefind scores those
+// 2-3x higher) stays on top however old it is.
+const RECENCY_WEIGHT = 0.2
 
 let pagefindPromise: Promise<PagefindModule> | null = null
 
@@ -89,12 +107,58 @@ export async function searchMessages(
     filters.service = options.services
   }
 
-  const response = await pagefind.search(
-    query,
-    Object.keys(filters).length ? { filters } : undefined
+  const searchOptions: PagefindSearchOptions = Object.keys(filters).length
+    ? { filters }
+    : {}
+
+  // Two passes over the same match set: one by relevance, one by date. The
+  // date pass is only used for its ordering, which avoids pulling a fragment
+  // per result just to read a date off it.
+  const [byRelevance, byDate] = await Promise.all([
+    pagefind.search(query, searchOptions),
+    pagefind
+      .search(query, { ...searchOptions, sort: { date: "desc" } })
+      .catch(() => null),
+  ])
+
+  const results = byRelevance.results ?? []
+
+  return applyRecencyWeighting(results, byDate?.results ?? [])
+}
+
+// Re-rank relevance-ordered results so newer posts win among comparable
+// matches. `byDate` is the same set ordered newest-first; a post's position in
+// it stands in for its age, which keeps the weighting relative to the result
+// set rather than to a fixed date (a query about an old change still ranks its
+// most recent posts first).
+function applyRecencyWeighting(
+  byRelevance: PagefindResult[],
+  byDate: PagefindResult[]
+): PagefindResult[] {
+  if (byRelevance.length < 2 || byDate.length < 2) return byRelevance
+
+  const oldestPosition = byDate.length - 1
+  const datePositions = new Map(
+    byDate.map((result, index) => [result.id, index])
   )
 
-  return response.results ?? []
+  return byRelevance
+    .map((result, index) => {
+      // Anything the date pass did not return is treated as oldest, so a
+      // missing date can only cost a post its lift, never invent one.
+      const position = datePositions.get(result.id) ?? oldestPosition
+      const recency = 1 - position / oldestPosition
+
+      return {
+        result,
+        // Relevance order breaks ties, so equally recent hits keep Pagefind's
+        // ordering rather than shuffling between searches.
+        index,
+        score: result.score * (1 + RECENCY_WEIGHT * recency),
+      }
+    })
+    .sort((a, b) => b.score - a.score || a.index - b.index)
+    .map((entry) => entry.result)
 }
 
 const escapeHtml = (value: string) =>


### PR DESCRIPTION
## Why

Message Center posts are change alerts, so a 2024 post should not outrank a comparable 2026 one. Pagefind's relevance scores sit in tight clusters — the top hits for `conditional access policy` score 48.42, 48.28, 48.05, 47.79 — which left the ordering *within* a cluster effectively arbitrary with respect to date.

## How

A second Pagefind pass sorted by date returns the same match set, so a result's position in it stands in for its age. Each relevance score is then scaled by up to 1.2×.

- Reading the date off the sorted pass rather than the fragments keeps this to **one extra query** instead of a fetch per result.
- The weighting is relative to the result set, so a query about an old change still ranks its most recent posts first rather than getting no ordering at all.
- Results missing from the date pass are treated as oldest, so a missing date can only cost a post its lift, never invent one.
- Relevance order breaks ties, so equally recent hits keep Pagefind's ordering instead of shuffling between searches.

The weight was picked by measurement: `0.15`, `0.25` and `0.4` were compared on real queries and the effect saturates by `0.15`, so `0.2` gives a clear preference without pulling up weak-but-recent matches.

## Effect (real UI, before → after)

| Query | Change |
| --- | --- |
| `conditional access policy` | A May 2024 post sat at #2; the top six now run Jul 2026 → Sep 2025 |
| `teams meeting` | Two Apr 2024 posts dropped off the first rows in favour of Aug 2026 ones |
| `sharepoint retention` | MC1115304 (score 142 vs ~48 for the rest) **keeps** #1 despite being Aug 2025 |
| `basic authentication retirement` | The canonical 2023 post stays above the 2026 one |

The last two are the point: a decisively better match still wins however old it is.

## RSS

The feed already existed — `/rss.xml`, 500 items, generated by `@build/Update-Site.ps1` and declared as `<link rel="alternate">` in `<head>` — but nothing in the UI pointed at it. Adds an RSS icon to the header before the GitHub icon, as a plain `<a>` rather than `next/link` since `rss.xml` is a static file, not a route the client router can navigate to.

Verified the icon renders and navigates to the feed, and that the feed parses as well-formed RSS with all 500 items carrying `title`, `link`, `guid`, `pubDate` and `description`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1m5RhkNMqsFRDnDSmtiBh

---
_Generated by [Claude Code](https://claude.ai/code/session_01J1m5RhkNMqsFRDnDSmtiBh)_