### PR TITLE
Rebuild the site as soon as new data lands, with a staleness watchdog

### DIFF
--- a/.github/workflows/update-mc-data.yml
+++ b/.github/workflows/update-mc-data.yml
@@ -54,7 +54,12 @@ jobs:
       - name: Update repo
         id: commit
         run: |
-          if [[ `git status --porcelain` ]]; then
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            # PR runs validate the refresh on a detached merge commit; there is
+            # no branch to push to, so publishing data is a main-only concern.
+            echo "PR validation run; skipping commit"
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+          elif [[ `git status --porcelain` ]]; then
             # Changes
             echo "Updating repo"
             git config --global user.name 'Merill Fernando'

--- a/.github/workflows/update-mc-data.yml
+++ b/.github/workflows/update-mc-data.yml
@@ -11,22 +11,33 @@ on:
       - '@data/**'
   pull_request:
     branches: [ "main" ]
-  # Refresh data hourly
+  # Refresh data hourly. Runs at :17 rather than :00 because GitHub's
+  # best-effort scheduler sheds load at the top of the hour first, so an
+  # off-peak minute is less likely to be delayed or dropped.
   schedule:
-    - cron:  '0 * * * *'
-    
+    - cron:  '17 * * * *'
+
   # Allows to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 permissions:
   id-token: write
   contents: write
-  
+  # Needed to dispatch the site build after pushing new data.
+  actions: write
+
+# Serialize refreshes so a delayed scheduled run can't race a later one and
+# fail its push; queued runs coalesce while one is in progress.
+concurrency:
+  group: "data-refresh"
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
-    steps:          
+    steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
       - name: Get Message Center and Roadmap data
@@ -41,6 +52,7 @@ jobs:
         shell: pwsh
         
       - name: Update repo
+        id: commit
         run: |
           if [[ `git status --porcelain` ]]; then
             # Changes
@@ -49,7 +61,51 @@ jobs:
             git config --global user.email 'merill@users.noreply.github.com'
             git add -A && git commit -m "Daily automation"
             git push
+            echo "pushed=true" >> "$GITHUB_OUTPUT"
           else
             # No changes
             echo "No changes"
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # The push above can never start the site build by itself: commits made
+      # with the workflow's GITHUB_TOKEN do not fire push-triggered workflows
+      # (GitHub's recursion guard). workflow_dispatch is the documented
+      # exception, so kick the build explicitly instead of waiting up to four
+      # hours for the site workflow's fallback cron.
+      - name: Rebuild site with new data
+        if: github.ref == 'refs/heads/main' && steps.commit.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run update-mc-site.yml --ref main
+
+      # Self-healing fallback: if a rebuild was missed (dropped cron slot,
+      # failed dispatch, failed build or deploy), this hourly run notices the
+      # live site serving older data than the repo and dispatches a rebuild.
+      # Skipped when this run just pushed (the step above already dispatched)
+      # and when a build is already queued or running.
+      - name: Rebuild site if live site is stale
+        if: github.ref == 'refs/heads/main' && steps.commit.outputs.pushed == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          repo_max=$(jq -r '[.[].LastModifiedDateTime // empty] | max // empty' '@data/messages-index.json')
+          live_max=$(curl -sf --max-time 30 https://mc.merill.net/messages-index.json | jq -r '[.[].LastModifiedDateTime // empty] | max // empty' || true)
+          echo "repo: ${repo_max:-none} live: ${live_max:-unreachable}"
+          if [ -z "$repo_max" ] || [ -z "$live_max" ]; then
+            echo "Skipping freshness check (index missing or live site unreachable)."
+            exit 0
+          fi
+          if [[ "$repo_max" > "$live_max" ]]; then
+            active=$(gh run list --workflow update-mc-site.yml --status in_progress --json databaseId --jq length)
+            queued=$(gh run list --workflow update-mc-site.yml --status queued --json databaseId --jq length)
+            if [ "$active" = "0" ] && [ "$queued" = "0" ]; then
+              echo "Live site is stale; dispatching a rebuild."
+              gh workflow run update-mc-site.yml --ref main
+              echo "Live site was stale (site $live_max, repo $repo_max); rebuild dispatched." >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "A site build is already queued or running; not dispatching another."
+            fi
+          else
+            echo "Live site is up to date."
           fi

--- a/.github/workflows/update-mc-site.yml
+++ b/.github/workflows/update-mc-site.yml
@@ -10,9 +10,12 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-  # Rebuild every four hours so new Message Center posts reach the site within
-  # hours instead of waiting for a twice-daily build. Runs at half past the hour
-  # so the hourly data refresh has already committed.
+  # Fallback rebuild every four hours. The primary trigger is the data
+  # workflow, which dispatches a build whenever it pushes new data (its pushes
+  # cannot fire the `push` trigger above because GITHUB_TOKEN commits never
+  # start workflows) and whenever it finds the live site serving stale data.
+  # This cron only covers the case where that dispatch chain breaks. Runs at
+  # half past the hour, an off-peak minute for GitHub's best-effort scheduler.
   schedule:
     - cron:  '30 */4 * * *'
 
@@ -32,6 +35,9 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    # A hung build would otherwise hold the "pages" concurrency group for the
+    # six-hour default, blocking every queued deployment behind it.
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -86,6 +92,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: build
     steps:
       - name: Deploy to GitHub Pages

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Microsoft 365 Message Center Archive
 
-This site is a simple archive of the Microsoft 365 Message Center and Microsoft 365 Roadmap. Message Center and Roadmap data is refreshed hourly and the site is rebuilt every four hours, providing a simple way to search and view posts.
+This site is a simple archive of the Microsoft 365 Message Center and Microsoft 365 Roadmap. Message Center and Roadmap data is refreshed hourly, and each refresh that lands new data immediately kicks off a site rebuild (with an hourly staleness check and a four-hour scheduled rebuild as fallbacks), providing a simple way to search and view posts.
 
 I created this site so I can link to it from my weekly newsletter [Entra.News](https://entra.news) so folks could ready the message center post without having to log into the admin center.
 

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -121,6 +121,20 @@ export default function AboutPage() {
         <CardContent className="readable-card-content space-y-5">
           <div>
             <h2 className="mb-3 text-xl font-semibold text-foreground">
+              August 27, 2026
+            </h2>
+            <ul>
+              <li>
+                New and updated posts now reach the site within minutes instead
+                of hours. The hourly data refresh kicks off a site build as soon
+                as it lands new data and also checks that the live site is not
+                serving stale data, rather than relying only on a rebuild
+                scheduled every four hours.
+              </li>
+            </ul>
+          </div>
+          <div>
+            <h2 className="mb-3 text-xl font-semibold text-foreground">
               August 22, 2026
             </h2>
             <ul>


### PR DESCRIPTION
## Problem

The site only rebuilt on a four-hour cron. Data commits are pushed with the workflow's `GITHUB_TOKEN`, which never fires push-triggered workflows (GitHub's recursion guard), so the cron was the *only* path from "new data on main" to "site rebuilt". On Aug 27 GitHub's best-effort scheduler stalled for ~7 hours (no scheduled run of either workflow after 02:51 UTC), and the site served data hours behind the repo — MC1462460 sat in `@data/messages.json` unrendered until a manual dispatch at 09:59 UTC.

## Changes

- **Event-driven rebuilds** — after the hourly data refresh pushes new data, it dispatches `update-mc-site` via `gh workflow run`. `workflow_dispatch` is the documented exemption from the recursion guard, so the built-in token suffices (new `actions: write` permission; no PAT). New posts reach the site in ~10 minutes instead of up to 4+ hours.
- **Staleness watchdog** — when a data run has nothing to push, it compares the live site's `messages-index.json` newest `LastModifiedDateTime` against the repo's copy and dispatches a rebuild if the site is behind and no build is already queued or running. Heals dropped cron slots, failed dispatches, and failed builds/deploys within an hour.
- **Scheduler-friendly cron** — the data refresh moves from `:00` (the minute GitHub sheds first under load) to `:17`. The four-hour site cron stays as a fallback.
- **Hang protection** — `timeout-minutes` on all three jobs and a `data-refresh` concurrency group, so a hung build can't hold the `pages` concurrency queue for the six-hour default and delayed data runs can't race each other's pushes.
- README pipeline description and an About-page release-notes entry updated to match.

## Verification

- Both workflow files parse as valid YAML.
- The watchdog's `jq` expression tested against the real `@data/messages-index.json`.
- The watchdog script dry-run with stubbed `curl`/`gh` across four scenarios (stale → dispatches; fresh → no-op; site unreachable → skips; stale with a build in flight → no duplicate dispatch).
- `tsc --noEmit` passes; the About-page change mirrors the existing release-notes markup.

Residual gap (out of repo scope): a total GitHub scheduler stall also pauses data ingestion itself; covering that requires an external timer calling the `workflow_dispatch` API with a fine-grained PAT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015WNjXCrea46ocEmRGEtN1M

---
_Generated by [Claude Code](https://claude.ai/code/session_015WNjXCrea46ocEmRGEtN1M)_